### PR TITLE
Fixes #226 Normalize Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,6 +1341,8 @@ For example, a chord symbol A# with reference key E will return the numeric chor
 <p>Besides that it normalizes the suffix if <code>normalizeSuffix</code> is <code>true</code>.
 For example, <code>sus2</code> becomes <code>2</code>, <code>sus4</code> becomes <code>sus</code>.
 All suffix normalizations can be found in <code>src/normalize_mappings/suffix-mapping.txt</code>.</p>
+<p>When the chord is minor bass notes are normalzied off of the relative major
+of the root note. For example, <code>Em/A#</code> becomes <code>Em/Bb</code>.</p>
 
 **Kind**: instance method of [<code>Chord</code>](#Chord)  
 **Returns**: [<code>Chord</code>](#Chord) - <p>the normalized chord</p>  

--- a/README.md
+++ b/README.md
@@ -1341,7 +1341,7 @@ For example, a chord symbol A# with reference key E will return the numeric chor
 <p>Besides that it normalizes the suffix if <code>normalizeSuffix</code> is <code>true</code>.
 For example, <code>sus2</code> becomes <code>2</code>, <code>sus4</code> becomes <code>sus</code>.
 All suffix normalizations can be found in <code>src/normalize_mappings/suffix-mapping.txt</code>.</p>
-<p>When the chord is minor, bass notes are normalzied off of the relative major
+<p>When the chord is minor, bass notes are normalized off of the relative major
 of the root note. For example, <code>Em/A#</code> becomes <code>Em/Bb</code>.</p>
 
 **Kind**: instance method of [<code>Chord</code>](#Chord)  

--- a/README.md
+++ b/README.md
@@ -1341,7 +1341,7 @@ For example, a chord symbol A# with reference key E will return the numeric chor
 <p>Besides that it normalizes the suffix if <code>normalizeSuffix</code> is <code>true</code>.
 For example, <code>sus2</code> becomes <code>2</code>, <code>sus4</code> becomes <code>sus</code>.
 All suffix normalizations can be found in <code>src/normalize_mappings/suffix-mapping.txt</code>.</p>
-<p>When the chord is minor bass notes are normalzied off of the relative major
+<p>When the chord is minor, bass notes are normalzied off of the relative major
 of the root note. For example, <code>Em/A#</code> becomes <code>Em/Bb</code>.</p>
 
 **Kind**: instance method of [<code>Chord</code>](#Chord)  

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -241,7 +241,7 @@ class Chord {
    * For example, `sus2` becomes `2`, `sus4` becomes `sus`.
    * All suffix normalizations can be found in `src/normalize_mappings/suffix-mapping.txt`.
    *
-   * When the chord is minor, bass notes are normalzied off of the relative major
+   * When the chord is minor, bass notes are normalized off of the relative major
    * of the root note. For example, `Em/A#` becomes `Em/Bb`.
    * @param {Key|string} [key=null] the key to normalize to
    * @param {Object} [options={}] options

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -10,7 +10,6 @@ import {
 
 import {
   deprecate,
-  isBlank,
   parseWithRegexes,
   presence,
 } from './utilities';
@@ -85,17 +84,18 @@ class Chord {
     }
 
     const keyObj = Key.wrap(key);
-    const rootKey = this.root.toChordSymbol(keyObj).normalizeEnharmonics(keyObj);
 
     let chordSymbolChord = new Chord({
       suffix: normalizeChordSuffix(this.suffix),
-      root: rootKey,
-      bass: this.bass?.toChordSymbol(keyObj).normalizeEnharmonics(rootKey),
+      root: this.root.toChordSymbol(keyObj),
+      bass: this.bass?.toChordSymbol(keyObj),
     });
 
     if (this.root.isMinor()) {
       chordSymbolChord = chordSymbolChord.makeMinor();
     }
+
+    chordSymbolChord = chordSymbolChord.normalize(key);
 
     return chordSymbolChord;
   }
@@ -240,6 +240,9 @@ class Chord {
    * Besides that it normalizes the suffix if `normalizeSuffix` is `true`.
    * For example, `sus2` becomes `2`, `sus4` becomes `sus`.
    * All suffix normalizations can be found in `src/normalize_mappings/suffix-mapping.txt`.
+   *
+   * When the chord is minor bass notes are normalzied off of the relative major
+   * of the root note. For example, `Em/A#` becomes `Em/Bb`.
    * @param {Key|string} [key=null] the key to normalize to
    * @param {Object} [options={}] options
    * @param {boolean} [options.normalizeSuffix=true] whether to normalize the chord suffix after transposing
@@ -248,14 +251,15 @@ class Chord {
   normalize(key = null, { normalizeSuffix = true } = {}) {
     const suffix = normalizeSuffix ? normalizeChordSuffix(this.suffix) : this.suffix;
 
-    if (isBlank(key)) {
-      return this.process('normalize').set({ suffix });
+    let bassRootKey = this.root.normalize();
+    if (this.root.isMinor() && this.bass) {
+      bassRootKey = this.root.transpose(3).removeMinor().normalize();
     }
 
     return this.set({
       suffix,
-      root: this.root.normalizeEnharmonics(key),
-      bass: this.bass ? this.bass.normalizeEnharmonics(this.root.toString()) : null,
+      root: this.root.normalize().normalizeEnharmonics(key),
+      bass: this.bass ? this.bass.normalize().normalizeEnharmonics(bassRootKey) : null,
     });
   }
 

--- a/src/chord.ts
+++ b/src/chord.ts
@@ -241,7 +241,7 @@ class Chord {
    * For example, `sus2` becomes `2`, `sus4` becomes `sus`.
    * All suffix normalizations can be found in `src/normalize_mappings/suffix-mapping.txt`.
    *
-   * When the chord is minor bass notes are normalzied off of the relative major
+   * When the chord is minor, bass notes are normalzied off of the relative major
    * of the root note. For example, `Em/A#` becomes `Em/Bb`.
    * @param {Key|string} [key=null] the key to normalize to
    * @param {Object} [options={}] options

--- a/src/key.ts
+++ b/src/key.ts
@@ -272,6 +272,12 @@ class Key {
     return this.clone();
   }
 
+  removeMinor() {
+    return this.set({
+      minor: false,
+    });
+  }
+
   normalizeEnharmonics(key: Key | string) {
     if (key) {
       const rootKeyString = Key.wrap(key).toString({ showMinor: true });

--- a/src/normalize_mappings/enharmonic-normalize.ts
+++ b/src/normalize_mappings/enharmonic-normalize.ts
@@ -25,6 +25,7 @@ export default {
   'D': {
     'D#': 'Eb',
     'A#': 'Bb',
+    'Gb': 'F#',
   },
   'E': {
     'Ab': 'G#',

--- a/test/chord_symbol/normalize.test.ts
+++ b/test/chord_symbol/normalize.test.ts
@@ -63,6 +63,36 @@ describe('Chord', () => {
           base: 'E', modifier: null, suffix: null, bassBase: 'E', bassModifier: null,
         });
       });
+
+      it('normalizes Em/A#', () => {
+        const chord = new Chord({
+          base: 'E',
+          modifier: '',
+          suffix: 'm',
+          bassBase: 'A',
+          bassModifier: '#',
+        });
+
+        const normalizedChord = chord.normalize();
+        expect(normalizedChord).toBeChord({
+          base: 'E', modifier: null, suffix: 'm', bassBase: 'B', bassModifier: 'b',
+        });
+      });
+
+      it('normalizes D/F#', () => {
+        const chord = new Chord({
+          base: 'D',
+          modifier: null,
+          suffix: null,
+          bassBase: 'F',
+          bassModifier: '#',
+        });
+
+        const normalizedChord = chord.normalize();
+        expect(normalizedChord).toBeChord({
+          base: 'D', modifier: null, suffix: null, bassBase: 'F', bassModifier: '#',
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Closes: #226 
- [x] consolidate all the normalize logic to the chord.normalize() function. 
- [x] normalize bass off of root
- [x] when root is minor, normalize bass from relative major of root