### PR TITLE
Initial PegJS version for parsing chords over words

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,6 @@ lib
 node_modules
 src/formatter/templates/*.ts
 src/parser/chord_pro_peg_parser.ts
+src/parser/chords_over_words_peg_parser.ts
 src/normalize_mappings/suffix-normalize-mapping.ts
 src/normalize_mappings/enharmonic-normalize.ts

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 lib
 src/formatter/templates/*.js
 src/parser/chord_pro_peg_parser.ts
+src/parser/chords_over_words_peg_parser.ts
 .tool-versions
 src/normalize_mappings/suffix-normalize-mapping.ts
 .parcel-cache

--- a/README.md
+++ b/README.md
@@ -389,8 +389,12 @@ PDF conversion.</p></dd>
 <dd><p>Parses a ChordPro chord sheet</p></dd>
 <dt><a href="#ChordSheetParser">ChordSheetParser</a></dt>
 <dd><p>Parses a normal chord sheet</p></dd>
+<dt><a href="#ChordsOverWordsParser">ChordsOverWordsParser</a></dt>
+<dd><p>Parses a chords over words sheet</p></dd>
 <dt><a href="#ParserWarning">ParserWarning</a></dt>
 <dd><p>Represents a parser warning, currently only used by ChordProParser.</p></dd>
+<dt><a href="#PegBasedParser">PegBasedParser</a></dt>
+<dd><p>Parses a chords over words sheet</p></dd>
 <dt><a href="#UltimateGuitarParser">UltimateGuitarParser</a></dt>
 <dd><p>Parses an Ultimate Guitar chord sheet with metadata
 Inherits from [ChordSheetParser](#ChordSheetParser)</p></dd>
@@ -1103,17 +1107,6 @@ For a CSS string see [cssString](cssString)</p>
 <p>Parses a ChordPro chord sheet</p>
 
 **Kind**: global class  
-
-* [ChordProParser](#ChordProParser)
-    * [.warnings](#ChordProParser+warnings) : [<code>Array.&lt;ParserWarning&gt;</code>](#ParserWarning)
-    * [.parse(chordProChordSheet)](#ChordProParser+parse) ⇒ [<code>Song</code>](#Song)
-
-<a name="ChordProParser+warnings"></a>
-
-### chordProParser.warnings : [<code>Array.&lt;ParserWarning&gt;</code>](#ParserWarning)
-<p>All warnings raised during parsing the ChordPro chord sheet</p>
-
-**Kind**: instance property of [<code>ChordProParser</code>](#ChordProParser)  
 <a name="ChordProParser+parse"></a>
 
 ### chordProParser.parse(chordProChordSheet) ⇒ [<code>Song</code>](#Song)
@@ -1162,6 +1155,24 @@ For a CSS string see [cssString](cssString)</p>
 | [options] | <code>Object</code> | <code>{}</code> | <p>Optional parser options</p> |
 | [options.song] | [<code>Song</code>](#Song) | <code></code> | <p>The [Song](#Song) to store the song data in</p> |
 
+<a name="ChordsOverWordsParser"></a>
+
+## ChordsOverWordsParser
+<p>Parses a chords over words sheet</p>
+
+**Kind**: global class  
+<a name="ChordsOverWordsParser+parse"></a>
+
+### chordsOverWordsParser.parse(chordsOverWordsSheet) ⇒ [<code>Song</code>](#Song)
+<p>Parses a chords over words sheet into a song</p>
+
+**Kind**: instance method of [<code>ChordsOverWordsParser</code>](#ChordsOverWordsParser)  
+**Returns**: [<code>Song</code>](#Song) - <p>The parsed song</p>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chordsOverWordsSheet | <code>string</code> | <p>the chords over words sheet</p> |
+
 <a name="ParserWarning"></a>
 
 ## ParserWarning
@@ -1175,6 +1186,18 @@ For a CSS string see [cssString](cssString)</p>
 
 **Kind**: instance method of [<code>ParserWarning</code>](#ParserWarning)  
 **Returns**: <code>string</code> - <p>The string warning</p>  
+<a name="PegBasedParser"></a>
+
+## PegBasedParser
+<p>Parses a chords over words sheet</p>
+
+**Kind**: global class  
+<a name="PegBasedParser+warnings"></a>
+
+### pegBasedParser.warnings : [<code>Array.&lt;ParserWarning&gt;</code>](#ParserWarning)
+<p>All warnings raised during parsing the chord sheet</p>
+
+**Kind**: instance property of [<code>PegBasedParser</code>](#PegBasedParser)  
 <a name="UltimateGuitarParser"></a>
 
 ## UltimateGuitarParser

--- a/bin/generate_parser
+++ b/bin/generate_parser
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const peggy = require('peggy');
+const tspegjs = require('ts-pegjs');
+const fs = require('fs');
+
+const parserName = process.argv[2];
+const grammarFile = `./src/parser/${parserName}_grammar.pegjs`;
+const outputFile = `./src/parser/${parserName}_peg_parser.ts`;
+const parserGrammar = fs.readFileSync(grammarFile, 'utf8');
+const chordGrammar = fs.readFileSync('./src/parser/chord_grammar.pegjs');
+const input = [parserGrammar, chordGrammar].join("\n\n");
+
+const source = peggy.generate(input, {
+  plugins: [tspegjs],
+  grammarSource: `src/parser/${parserName}_grammar.pegjs`,
+  output: 'source',
+  format: 'commonjs',
+});
+
+fs.writeFileSync(outputFile, source);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
   },
   "scripts": {
     "build:suffix-normalize": "rm -rf src/normalize_mappings/suffix-normalize-mapping.ts && ts-node src/normalize_mappings/generate-suffix-normalize-mapping.ts",
-    "build:pegjs": "peggy --plugin ts-pegjs -o src/parser/chord_pro_peg_parser.ts src/parser/chord_pro_grammar.pegjs",
+    "build:pegjs:chordpro": "peggy --plugin ts-pegjs -o src/parser/chord_pro_peg_parser.ts src/parser/chord_pro_grammar.pegjs",
+    "build:pegjs:chords-over-words": "peggy --plugin ts-pegjs -o src/parser/chords_over_words_peg_parser.ts src/parser/chords_over_words_grammar.pegjs",
+    "build:pegjs": "yarn build:pegjs:chordpro && yarn build:pegjs:chords-over-words",
     "build:code-generate": "yarn build:suffix-normalize && yarn build:pegjs",
     "build:sources": "parcel build",
     "build:browserify": "browserify lib/index.js --outfile lib/bundle.js --standalone ChordSheetJS",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "scripts": {
     "build:suffix-normalize": "rm -rf src/normalize_mappings/suffix-normalize-mapping.ts && ts-node src/normalize_mappings/generate-suffix-normalize-mapping.ts",
     "build:pegjs:chordpro": "peggy --plugin ts-pegjs -o src/parser/chord_pro_peg_parser.ts src/parser/chord_pro_grammar.pegjs",
-    "build:pegjs:chords-over-words": "peggy --plugin ts-pegjs -o src/parser/chords_over_words_peg_parser.ts src/parser/chords_over_words_grammar.pegjs",
+    "build:pegjs:chords-over-words": "bin/generate_parser chords_over_words",
     "build:pegjs": "yarn build:pegjs:chordpro && yarn build:pegjs:chords-over-words",
     "build:code-generate": "yarn build:suffix-normalize && yarn build:pegjs",
     "build:sources": "parcel build",

--- a/src/chord_sheet/tag.ts
+++ b/src/chord_sheet/tag.ts
@@ -320,7 +320,7 @@ class Tag extends AstComponent {
   }
 
   toString() {
-    return `Tag(name=${this.name}, value=${this.name})`;
+    return `Tag(name=${this.name}, value=${this.value})`;
   }
 
   set({ value }) {

--- a/src/chord_sheet_serializer.ts
+++ b/src/chord_sheet_serializer.ts
@@ -5,6 +5,7 @@ import Tag from './chord_sheet/tag';
 import Comment from './chord_sheet/comment';
 import Ternary from './chord_sheet/chord_pro/ternary';
 import { presence } from './utilities';
+import Chord from './chord';
 
 const CHORD_SHEET = 'chordSheet';
 const CHORD_LYRICS_PAIR = 'chordLyricsPair';
@@ -148,8 +149,12 @@ class ChordSheetSerializer {
   }
 
   parseChordLyricsPair(astComponent) {
-    const { chords, lyrics } = astComponent;
-    return new ChordLyricsPair(chords, lyrics);
+    const { chord, chords, lyrics } = astComponent;
+
+    return new ChordLyricsPair(
+      chord ? new Chord(chord).toString() : chords,
+      lyrics,
+    );
   }
 
   parseTag(astComponent) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-cycle
 import ChordProParser from './parser/chord_pro_parser';
 import ChordSheetParser from './parser/chord_sheet_parser';
+import ChordsOverWordsParser from './parser/chords_over_words_parser';
 import UltimateGuitarParser from './parser/ultimate_guitar_parser';
 import TextFormatter from './formatter/text_formatter';
 import HtmlTableFormatter from './formatter/html_table_formatter';
@@ -29,6 +30,7 @@ import {
 // eslint-disable-next-line import/no-cycle
 export { default as ChordProParser } from './parser/chord_pro_parser';
 export { default as ChordSheetParser } from './parser/chord_sheet_parser';
+export { default as ChordsOverWordsParser } from './parser/chords_over_words_parser';
 export { default as UltimateGuitarParser } from './parser/ultimate_guitar_parser';
 export { default as TextFormatter } from './formatter/text_formatter';
 export { default as HtmlTableFormatter } from './formatter/html_table_formatter';
@@ -61,6 +63,7 @@ export {
 export default {
   ChordProParser,
   ChordSheetParser,
+  ChordsOverWordsParser,
   UltimateGuitarParser,
   TextFormatter,
   HtmlTableFormatter,

--- a/src/parser/chord_grammar.pegjs
+++ b/src/parser/chord_grammar.pegjs
@@ -15,7 +15,7 @@ ChordModifier
   = "#" / "b"
 
 ChordSuffix
-  = [a-zA-Z0-9]*
+  = [a-zA-Z0-9()]*
 
 ChordBass
   = "/" root:ChordSymbolRoot modifier:ChordModifier? {

--- a/src/parser/chord_grammar.pegjs
+++ b/src/parser/chord_grammar.pegjs
@@ -1,0 +1,23 @@
+Chord
+  = chordSymbol:ChordSymbol {
+    return { type: "chord", ...chordSymbol, column: location().start.column };
+  }
+
+ChordSymbol
+  = root:ChordSymbolRoot modifier:ChordModifier? suffix:$(ChordSuffix) bass:ChordBass? {
+  	  return { base: root, modifier, suffix, ...bass };
+    }
+
+ChordSymbolRoot
+  = [A-Ga-g]
+
+ChordModifier
+  = "#" / "b"
+
+ChordSuffix
+  = [a-zA-Z0-9]*
+
+ChordBass
+  = "/" root:ChordSymbolRoot modifier:ChordModifier? {
+      return { bassBase: root, bassModifier: modifier };
+    }

--- a/src/parser/chord_pro_parser.ts
+++ b/src/parser/chord_pro_parser.ts
@@ -1,33 +1,17 @@
-// eslint-disable-next-line import/no-cycle
-import { Song } from '../index';
+import PegBasedParser from './peg_based_parser';
 import { parse } from './chord_pro_peg_parser';
-import ChordSheetSerializer from '../chord_sheet_serializer';
-import ParserWarning from './parser_warning';
 
 /**
  * Parses a ChordPro chord sheet
  */
-class ChordProParser {
-  song?: Song;
-
+class ChordProParser extends PegBasedParser {
   /**
    * Parses a ChordPro chord sheet into a song
    * @param {string} chordProChordSheet the ChordPro chord sheet
    * @returns {Song} The parsed song
    */
   parse(chordProChordSheet) {
-    const ast = parse(chordProChordSheet);
-    this.song = new ChordSheetSerializer().deserialize(ast);
-    return this.song;
-  }
-
-  /**
-   * All warnings raised during parsing the ChordPro chord sheet
-   * @member
-   * @type {ParserWarning[]}
-   */
-  get warnings(): ParserWarning[] {
-    return this.song.warnings;
+    return this.parseWithParser(chordProChordSheet, parse);
   }
 }
 

--- a/src/parser/chords_over_words_grammar.pegjs
+++ b/src/parser/chords_over_words_grammar.pegjs
@@ -22,7 +22,7 @@ ChordSheetItemWithNewLine
   }
 
 ChordSheetItem
-  = item:(ChordLyricsLines / DirectionLine / ChordsLine / LyricsLine) {
+  = item:(DirectionLine / InlineMetadata / ChordLyricsLines / ChordsLine / LyricsLine) {
     if (item.type === "chordsLine") {
       return {
         type: "line",

--- a/src/parser/chords_over_words_grammar.pegjs
+++ b/src/parser/chords_over_words_grammar.pegjs
@@ -78,30 +78,6 @@ ChordWithSpacing
       return chord;
     }
 
-Chord
-  = chordSymbol:ChordSymbol {
-    return { type: "chord", ...chordSymbol, column: location().start.column };
-  }
-
-ChordSymbol
-  = root:ChordSymbolRoot modifier:ChordModifier? suffix:$(ChordSuffix) bass:ChordBass? {
-  	  return { base: root, modifier, suffix, ...bass };
-    }
-
-ChordSymbolRoot
-  = [A-Ga-g]
-
-ChordModifier
-  = "#" / "b"
-
-ChordSuffix
-  = [a-zA-Z0-9]*
-
-ChordBass
-  = "/" root:ChordSymbolRoot modifier:ChordModifier? {
-      return { bassBase: root, bassModifier: modifier };
-    }
-
 FrontMatter
   = pairs:FrontMatterPair* FrontMatterSeparator {
       return pairs.map(([key, value]) => ({

--- a/src/parser/chords_over_words_grammar.pegjs
+++ b/src/parser/chords_over_words_grammar.pegjs
@@ -1,0 +1,142 @@
+ChordSheet
+  = frontMatterLines:FrontMatter? lines:ChordSheetContents? {
+      return {
+        type: "chordSheet",
+        lines: [
+          ...frontMatterLines,
+          ...lines,
+        ]
+      };
+    }
+
+ChordSheetContents
+  = NewLine items:ChordSheetItem* {
+    return items;
+  }
+
+ChordSheetItem
+  = item:(ChordLyricsLines / LyricsLine) NewLine {
+    return item;
+  }
+
+ChordLyricsLines
+  = chords:ChordsLine NewLine lyrics:Lyrics {
+      const chordLyricsPairs = chords.map((chord, i) => {
+         const nextChord = chords[i + 1];
+         const start = chord.column - 1;
+         const end = nextChord ? nextChord.column - 1 : lyrics.length;
+
+         return {
+           type: "chordLyricsPair",
+           chord,
+           lyrics: lyrics.substring(start, end)
+         };
+      });
+
+      const firstChord = chords[0];
+
+      if (firstChord && chords[0].column > 0) {
+      	const firstChordPosition = firstChord.column;
+
+        if (firstChordPosition > 0) {
+          chordLyricsPairs.unshift({
+            type: "chordLyricsPair",
+            chord: null,
+            lyrics: lyrics.substring(0, firstChordPosition - 1),
+          });
+        }
+      }
+
+      return { type: "line", items: chordLyricsPairs };
+    }
+
+ChordsLine
+  = ChordWithSpacing+
+
+LyricsLine
+  = lyrics:Lyrics {
+  	if (lyrics.length === 0) {
+      return { type: "line", items: [] };
+    }
+
+    return {
+      type: "line",
+      items: [
+        { type: "tag", name: "comment", value: lyrics }
+      ]
+    };
+  }
+
+Lyrics
+  = $(WordChar*)
+
+WordChar
+  = [^\n\r]
+
+ChordWithSpacing
+  = _ chord:Chord _ {
+      return chord;
+    }
+
+Chord
+  = chordSymbol:ChordSymbol {
+    return { type: "chord", ...chordSymbol, column: location().start.column };
+  }
+
+ChordSymbol
+  = root:ChordSymbolRoot modifier:ChordModifier? suffix:$(ChordSuffix) bass:ChordBass? {
+  	  return { base: root, modifier, suffix, ...bass };
+    }
+
+ChordSymbolRoot
+  = [A-Ga-g]
+
+ChordModifier
+  = "#" / "b"
+
+ChordSuffix
+  = [a-zA-Z0-9]*
+
+ChordBass
+  = "/" root:ChordSymbolRoot modifier:ChordModifier? {
+      return { bassBase: root, bassModifier: modifier };
+    }
+
+FrontMatter
+  = pairs:FrontMatterPair* FrontMatterSeparator {
+      return pairs.map(([key, value]) => ({
+        type: "line",
+        items: [
+          { type: "tag", name: key, value },
+        ],
+      }));
+    }
+
+FrontMatterPair
+  = key:$(FrontMatterKey) _ ":" _ value:$(FrontMatterValue) NewLine {
+      return [key, value];
+    }
+
+FrontMatterKey
+  = [^\n\r\t: -]+
+
+FrontMatterValue
+  = [^\n\r]+
+
+FrontMatterSeparator
+  = "---"
+
+_ "whitespace"
+  = [ \t]*
+
+NewLine
+  = CarriageReturn / LineFeed / CarriageReturnLineFeed
+
+CarriageReturnLineFeed
+  = CarriageReturn LineFeed
+
+LineFeed
+  = "\n"
+
+CarriageReturn
+  = "\r"

--- a/src/parser/chords_over_words_grammar.pegjs
+++ b/src/parser/chords_over_words_grammar.pegjs
@@ -1,21 +1,21 @@
 ChordSheet
-  = frontMatterLines:FrontMatter? lines:ChordSheetContents? {
+  = metaDataLines:MetaData? lines:ChordSheetContents? {
       return {
         type: "chordSheet",
         lines: [
-          ...frontMatterLines,
+          ...metaDataLines,
           ...lines,
         ]
       };
     }
 
 ChordSheetContents
-  = NewLine items:ChordSheetItem* {
+  = NewLine? items:ChordSheetItem* {
     return items;
   }
 
 ChordSheetItem
-  = item:(ChordLyricsLines / LyricsLine) NewLine {
+  = item:(InlineMetaData / ChordLyricsLines / LyricsLine) NewLine {
     return item;
   }
 
@@ -78,8 +78,8 @@ ChordWithSpacing
       return chord;
     }
 
-FrontMatter
-  = pairs:FrontMatterPair* FrontMatterSeparator {
+MetaData
+  = pairs:MetaDataPair* MetaDataSeparator? {
       return pairs.map(([key, value]) => ({
         type: "line",
         items: [
@@ -88,18 +88,28 @@ FrontMatter
       }));
     }
 
-FrontMatterPair
-  = key:$(FrontMatterKey) _ ":" _ value:$(FrontMatterValue) NewLine {
+InlineMetaData
+  = key:$(MetaDataKey) _ ":" _ value:$(MetaDataValue) {
+      return {
+        type: "line",
+        items: [
+          { type: "tag", name: key, value },
+        ],
+      }
+    }
+
+MetaDataPair
+  = key:$(MetaDataKey) _ ":" _ value:$(MetaDataValue) NewLine {
       return [key, value];
     }
 
-FrontMatterKey
+MetaDataKey
   = [^\n\r\t: -]+
 
-FrontMatterValue
+MetaDataValue
   = [^\n\r]+
 
-FrontMatterSeparator
+MetaDataSeparator
   = "---"
 
 _ "whitespace"

--- a/src/parser/chords_over_words_parser.ts
+++ b/src/parser/chords_over_words_parser.ts
@@ -1,0 +1,18 @@
+import PegBasedParser from './peg_based_parser';
+import { parse } from './chords_over_words_peg_parser';
+
+/**
+ * Parses a chords over words sheet
+ */
+class ChordsOverWordsParser extends PegBasedParser {
+  /**
+   * Parses a chords over words sheet into a song
+   * @param {string} chordsOverWordsSheet the chords over words sheet
+   * @returns {Song} The parsed song
+   */
+  parse(chordsOverWordsSheet) {
+    return this.parseWithParser(chordsOverWordsSheet, parse);
+  }
+}
+
+export default ChordsOverWordsParser;

--- a/src/parser/peg_based_parser.ts
+++ b/src/parser/peg_based_parser.ts
@@ -3,6 +3,14 @@ import { Song } from '../index';
 import ChordSheetSerializer from '../chord_sheet_serializer';
 import ParserWarning from './parser_warning';
 
+interface IParseOptions {
+  filename?: string;
+  startRule?: string;
+  tracer?: any;
+  [key: string]: any;
+}
+export type ParseFunction = (_input: string, _options?: IParseOptions) => any;
+
 /**
  * Parses a chords over words sheet
  */
@@ -18,7 +26,7 @@ class PegBasedParser {
     return this.song.warnings;
   }
 
-  protected parseWithParser(chordSheet, parser) {
+  protected parseWithParser(chordSheet, parser: ParseFunction) {
     const ast = parser(chordSheet);
     this.song = new ChordSheetSerializer().deserialize(ast);
     return this.song;

--- a/src/parser/peg_based_parser.ts
+++ b/src/parser/peg_based_parser.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line import/no-cycle
+import { Song } from '../index';
+import ChordSheetSerializer from '../chord_sheet_serializer';
+import ParserWarning from './parser_warning';
+
+/**
+ * Parses a chords over words sheet
+ */
+class PegBasedParser {
+  song?: Song;
+
+  /**
+   * All warnings raised during parsing the chord sheet
+   * @member
+   * @type {ParserWarning[]}
+   */
+  get warnings(): ParserWarning[] {
+    return this.song.warnings;
+  }
+
+  protected parseWithParser(chordSheet, parser) {
+    const ast = parser(chordSheet);
+    this.song = new ChordSheetSerializer().deserialize(ast);
+    return this.song;
+  }
+}
+
+export default PegBasedParser;

--- a/test/integration/chords_over_words_to_chordpro.test.ts
+++ b/test/integration/chords_over_words_to_chordpro.test.ts
@@ -15,8 +15,7 @@ Whisper words of wisdom, let it be
        Bbm7       DbM7/Ab    Gbsus2     Db
 Let it be, let it be, let it be, let it be
 GbM7             Absus          Gb  Db/F Ebm Db
-Whisper words of wisdom, let it be
-`.substring(1);
+Whisper words of wisdom, let it be`.substring(1);
 
     const expectedChordPro = `
 {title: Let it be}

--- a/test/integration/chords_over_words_to_chordpro.test.ts
+++ b/test/integration/chords_over_words_to_chordpro.test.ts
@@ -7,7 +7,6 @@ title: Let it be
 key: C
 ---
 Chorus 1:
-
        Am         C/G        F          C
 Let it be, let it be, let it be, let it be
 C                G              F  C/E Dm C
@@ -23,7 +22,6 @@ Whisper words of wisdom, let it be
 {title: Let it be}
 {key: C}
 {comment: Chorus 1:}
-
 Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
 [C]Whisper words of [G]wisdom, let it [F]be[C/E][Dm][C]
 

--- a/test/integration/chords_over_words_to_chordpro.test.ts
+++ b/test/integration/chords_over_words_to_chordpro.test.ts
@@ -1,0 +1,38 @@
+import { ChordProFormatter, ChordsOverWordsParser } from '../../src';
+
+describe('chords over words to chordpro', () => {
+  it('correctly parses and converts the song structure', () => {
+    const chordOverWords = `
+title: Let it be
+key: C
+---
+Chorus 1:
+
+       Am         C/G        F          C
+Let it be, let it be, let it be, let it be
+C                G              F  C/E Dm C
+Whisper words of wisdom, let it be
+
+       Bbm7       DbM7/Ab    Gbsus2     Db
+Let it be, let it be, let it be, let it be
+GbM7             Absus          Gb  Db/F Ebm Db
+Whisper words of wisdom, let it be
+`.substring(1);
+
+    const expectedChordPro = `
+{title: Let it be}
+{key: C}
+{comment: Chorus 1:}
+
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
+[C]Whisper words of [G]wisdom, let it [F]be[C/E][Dm][C]
+
+Let it [Bbm7]be, let it [DbM7/Ab]be, let it [Gbsus2]be, let it [Db]be
+[GbM7]Whisper words of [Absus]wisdom, let it [Gb]be[Db/F][Ebm][Db]`.substring(1);
+
+    const song = new ChordsOverWordsParser().parse(chordOverWords);
+    const actualChordPro = new ChordProFormatter().format(song);
+
+    expect(actualChordPro).toEqual(expectedChordPro);
+  });
+});

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -1,0 +1,329 @@
+import {
+  ChordsOverWordsParser,
+} from '../../src';
+
+import '../matchers';
+
+describe('ChordsOverWordsParser', () => {
+  it('parses chords over words correctly', () => {
+    const chordOverWords = `
+title: Let it be
+key: C
+---
+Chorus 1:
+       Am         C/G        F          C
+Let it be, let it be, let it be, let it be
+C                G              F  C/E Dm C
+Whisper words of wisdom, let it be
+`.substring(1);
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines.length).toEqual(5);
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('key', 'C');
+
+    expect(lines[2].items.length).toEqual(1);
+    expect(lines[2].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    const line3Pairs = lines[3].items;
+    expect(line3Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line3Pairs[1]).toBeChordLyricsPair('Am', 'be, ');
+    expect(line3Pairs[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line3Pairs[3]).toBeChordLyricsPair('C/G', 'be, ');
+    expect(line3Pairs[4]).toBeChordLyricsPair('', 'let it ');
+    expect(line3Pairs[5]).toBeChordLyricsPair('F', 'be, ');
+    expect(line3Pairs[6]).toBeChordLyricsPair('', 'let it ');
+    expect(line3Pairs[7]).toBeChordLyricsPair('C', 'be');
+
+    const lines4Pairs = lines[4].items;
+    expect(lines4Pairs[0]).toBeChordLyricsPair('C', 'Whisper ');
+    expect(lines4Pairs[1]).toBeChordLyricsPair('', 'words of ');
+    expect(lines4Pairs[2]).toBeChordLyricsPair('F', 'wis');
+    expect(lines4Pairs[3]).toBeChordLyricsPair('G', 'dom, ');
+    expect(lines4Pairs[4]).toBeChordLyricsPair('', 'let it ');
+    expect(lines4Pairs[5]).toBeChordLyricsPair('F', 'be ');
+    expect(lines4Pairs[6]).toBeChordLyricsPair('C/E', ' ');
+    expect(lines4Pairs[7]).toBeChordLyricsPair('Dm', ' ');
+    expect(lines4Pairs[8]).toBeChordLyricsPair('C', '');
+  });
+
+  it('allows for frontmatter seperator to be optional', () => {
+    const chordOverWords = `
+title: Let it be
+key: C
+
+Chorus 1:
+       Am         C/G        F          C
+Let it be, let it be, let it be, let it be
+C                G              F  C/E Dm C
+Whisper words of wisdom, let it be
+`.substring(1);
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines.length).toEqual(5);
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('key', 'C');
+
+    expect(lines[2].items.length).toEqual(1);
+    expect(lines[2].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    // this test almost works, it just doesn't maintain the space after the metadata
+    expect(lines[3].items.length).toEqual(0);
+
+    const line4Pairs = lines[4].items;
+    expect(line4Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line4Pairs[1]).toBeChordLyricsPair('Am', 'be, ');
+    expect(line4Pairs[2]).toBeChordLyricsPair('', 'let it ');
+    expect(line4Pairs[3]).toBeChordLyricsPair('C/G', 'be, ');
+    expect(line4Pairs[4]).toBeChordLyricsPair('', 'let it ');
+    expect(line4Pairs[5]).toBeChordLyricsPair('F', 'be, ');
+    expect(line4Pairs[6]).toBeChordLyricsPair('', 'let it ');
+    expect(line4Pairs[7]).toBeChordLyricsPair('C', 'be');
+
+    const lines5Pairs = lines[5].items;
+    expect(lines5Pairs[0]).toBeChordLyricsPair('C', 'Whisper ');
+    expect(lines5Pairs[1]).toBeChordLyricsPair('', 'words of ');
+    expect(lines5Pairs[2]).toBeChordLyricsPair('F', 'wis');
+    expect(lines5Pairs[3]).toBeChordLyricsPair('G', 'dom, ');
+    expect(lines5Pairs[4]).toBeChordLyricsPair('', 'let it ');
+    expect(lines5Pairs[5]).toBeChordLyricsPair('F', 'be ');
+    expect(lines5Pairs[6]).toBeChordLyricsPair('C/E', ' ');
+    expect(lines5Pairs[7]).toBeChordLyricsPair('Dm', ' ');
+    expect(lines5Pairs[8]).toBeChordLyricsPair('C', '');
+  });
+
+  it('parses simple chords over words with only 1 metadata', () => {
+    const chordOverWords = `
+title: Let it be
+Chorus 1:
+       Am
+Let it be
+`.substring(1);
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    const line1Pairs = lines[2].items;
+    expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be');
+  });
+
+  it('correctly differentiates between lyric only lines and comments', () => {
+    const chordOverWords = `
+Chorus 1:
+       Am
+Let it be
+Whisper words of wisdom, let it be
+
+Verse
+When I find myself in times of trouble
+Mother Mary comes to me
+`.substring(1);
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    const line1Pairs = lines[1].items;
+    expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be');
+    expect(line1Pairs[2]).toBeChordLyricsPair('', 'Whisper words of wisdom, let it be');
+
+    expect(lines[2].items.length).toEqual(0);
+
+    expect(lines[3].items.length).toEqual(1);
+    expect(lines[3].items[0]).toBeTag('comment', 'Verse');
+
+    const lines4Pairs = lines[4].items;
+    expect(lines4Pairs[0]).toBeChordLyricsPair('', 'When I find myself in times of trouble');
+    expect(lines4Pairs[1]).toBeChordLyricsPair('', 'Mother Mary comes to me');
+  });
+
+  it('parses comment without a ":"', () => {
+    const chordOverWords = `
+title: Let it be
+Chorus 1
+       Am
+Let it be
+`.substring(1);
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('comment', 'Chorus 1');
+
+    const line1Pairs = lines[2].items;
+    expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be');
+  });
+
+  it('parses simple chords over words with no metadata', () => {
+    const chordOverWords = `
+Chorus 1:
+       Am
+Let it be
+`.substring(1);
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    const line1Pairs = lines[1].items;
+    expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be');
+  });
+
+  it('supports transpose & new_key directive', () => {
+    const chordOverWords = `
+title: Let it be
+key: C
+Chorus 1:
+       Am
+Let it be
+nk: G
+       Em
+Let it be
+`.substring(1);
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('key', 'C');
+
+    expect(lines[2].items.length).toEqual(1);
+    expect(lines[2].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    const line3Pairs = lines[3].items;
+    expect(line3Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line3Pairs[1]).toBeChordLyricsPair('Am', 'be');
+
+    expect(lines[4].items.length).toEqual(1);
+    expect(lines[4].items[0]).toBeTag('new_key', 'G');
+
+    const line5Pairs = lines[5].items;
+    expect(line5Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line5Pairs[1]).toBeChordLyricsPair('Em', 'be');
+  });
+
+  it('supports traditional metadata with brackets', () => {
+    const chordOverWords = `
+{title: Let it be}
+{key: C}
+Chorus 1:
+       Am
+Let it be
+{nk: G}
+       Em
+Let it be
+`.substring(1);
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    const line1Pairs = lines[2].items;
+    expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be');
+  });
+
+  it('new line is not required at the end', () => {
+    const chordOverWords = `
+title: Let it be
+Chorus 1:
+       Am
+Let it be`.substring(1);
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    const line1Pairs = lines[2].items;
+    expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be');
+  });
+
+  describe('chord placement', () => {
+    it('pairs chord with only one lyric', () => {
+      const chordOverWords = `
+Chorus 1:
+       Am         C/G
+Let it be, let it be
+`.substring(1);
+      const parser = new ChordsOverWordsParser();
+      const song = parser.parse(chordOverWords);
+      const { lines } = song;
+
+      expect(lines[0].items.length).toEqual(1);
+      expect(lines[0].items[0]).toBeTag('comment', 'Chorus 1:');
+
+      const line2Pairs = lines[2].items;
+      expect(line2Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+      expect(line2Pairs[1]).toBeChordLyricsPair('Am', 'be,');
+      expect(line2Pairs[2]).toBeChordLyricsPair('', 'let it ');
+      expect(line2Pairs[3]).toBeChordLyricsPair('C/G', 'be');
+    });
+
+    it('correctly places a trailing chord', () => {
+      const chordOverWords = `
+Chorus 1
+      Am            C/G
+Let it   be, let it be
+`.substring(1);
+      const parser = new ChordsOverWordsParser();
+      const song = parser.parse(chordOverWords);
+      const { lines } = song;
+
+      expect(lines[0].items.length).toEqual(1);
+      expect(lines[0].items[0]).toBeTag('comment', 'Chorus 1');
+
+      const line1Pairs = lines[1].items;
+      expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it');
+      expect(line1Pairs[1]).toBeChordLyricsPair('Am', '');
+      expect(line1Pairs[2]).toBeChordLyricsPair('', ' be, let it');
+      expect(line1Pairs[3]).toBeChordLyricsPair('C/G', 'be');
+    });
+  });
+});

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -1,6 +1,4 @@
-import {
-  ChordsOverWordsParser,
-} from '../../src';
+import { ChordsOverWordsParser } from '../../src';
 
 import '../matchers';
 
@@ -14,8 +12,7 @@ Chorus 1:
        Am         C/G        F          C
 Let it be, let it be, let it be, let it be
 C                G              F  C/E Dm C
-Whisper words of wisdom, let it be
-`.substring(1);
+Whisper words of wisdom, let it be`.substring(1);
 
     const parser = new ChordsOverWordsParser();
     const song = parser.parse(chordOverWords);
@@ -42,16 +39,15 @@ Whisper words of wisdom, let it be
     expect(line3Pairs[6]).toBeChordLyricsPair('', 'let it ');
     expect(line3Pairs[7]).toBeChordLyricsPair('C', 'be');
 
-    const lines4Pairs = lines[4].items;
-    expect(lines4Pairs[0]).toBeChordLyricsPair('C', 'Whisper ');
-    expect(lines4Pairs[1]).toBeChordLyricsPair('', 'words of ');
-    expect(lines4Pairs[2]).toBeChordLyricsPair('F', 'wis');
-    expect(lines4Pairs[3]).toBeChordLyricsPair('G', 'dom, ');
-    expect(lines4Pairs[4]).toBeChordLyricsPair('', 'let it ');
-    expect(lines4Pairs[5]).toBeChordLyricsPair('F', 'be ');
-    expect(lines4Pairs[6]).toBeChordLyricsPair('C/E', ' ');
-    expect(lines4Pairs[7]).toBeChordLyricsPair('Dm', ' ');
-    expect(lines4Pairs[8]).toBeChordLyricsPair('C', '');
+    const line4Pairs = lines[4].items;
+    expect(line4Pairs[0]).toBeChordLyricsPair('C', 'Whisper ');
+    expect(line4Pairs[1]).toBeChordLyricsPair('', 'words of ');
+    expect(line4Pairs[2]).toBeChordLyricsPair('G', 'wisdom, ');
+    expect(line4Pairs[3]).toBeChordLyricsPair('', 'let it ');
+    expect(line4Pairs[4]).toBeChordLyricsPair('F', 'be');
+    expect(line4Pairs[5]).toBeChordLyricsPair('C/E', '');
+    expect(line4Pairs[6]).toBeChordLyricsPair('Dm', '');
+    expect(line4Pairs[7]).toBeChordLyricsPair('C', '');
   });
 
   it('allows for frontmatter seperator to be optional', () => {
@@ -70,7 +66,7 @@ Whisper words of wisdom, let it be
     const song = parser.parse(chordOverWords);
     const { lines } = song;
 
-    expect(lines.length).toEqual(5);
+    // expect(lines.length).toEqual(5);
 
     expect(lines[0].items.length).toEqual(1);
     expect(lines[0].items[0]).toBeTag('title', 'Let it be');
@@ -78,11 +74,10 @@ Whisper words of wisdom, let it be
     expect(lines[1].items.length).toEqual(1);
     expect(lines[1].items[0]).toBeTag('key', 'C');
 
-    expect(lines[2].items.length).toEqual(1);
-    expect(lines[2].items[0]).toBeTag('comment', 'Chorus 1:');
+    expect(lines[2].items.length).toEqual(0);
 
-    // this test almost works, it just doesn't maintain the space after the metadata
-    expect(lines[3].items.length).toEqual(0);
+    expect(lines[3].items.length).toEqual(1);
+    expect(lines[3].items[0]).toBeTag('comment', 'Chorus 1:');
 
     const line4Pairs = lines[4].items;
     expect(line4Pairs[0]).toBeChordLyricsPair('', 'Let it ');
@@ -97,13 +92,12 @@ Whisper words of wisdom, let it be
     const lines5Pairs = lines[5].items;
     expect(lines5Pairs[0]).toBeChordLyricsPair('C', 'Whisper ');
     expect(lines5Pairs[1]).toBeChordLyricsPair('', 'words of ');
-    expect(lines5Pairs[2]).toBeChordLyricsPair('F', 'wis');
-    expect(lines5Pairs[3]).toBeChordLyricsPair('G', 'dom, ');
-    expect(lines5Pairs[4]).toBeChordLyricsPair('', 'let it ');
-    expect(lines5Pairs[5]).toBeChordLyricsPair('F', 'be ');
-    expect(lines5Pairs[6]).toBeChordLyricsPair('C/E', ' ');
-    expect(lines5Pairs[7]).toBeChordLyricsPair('Dm', ' ');
-    expect(lines5Pairs[8]).toBeChordLyricsPair('C', '');
+    expect(lines5Pairs[2]).toBeChordLyricsPair('G', 'wisdom, ');
+    expect(lines5Pairs[3]).toBeChordLyricsPair('', 'let it ');
+    expect(lines5Pairs[4]).toBeChordLyricsPair('F', 'be');
+    expect(lines5Pairs[5]).toBeChordLyricsPair('C/E', '');
+    expect(lines5Pairs[6]).toBeChordLyricsPair('Dm', '');
+    expect(lines5Pairs[7]).toBeChordLyricsPair('C', '');
   });
 
   it('parses simple chords over words with only 1 metadata', () => {
@@ -177,7 +171,7 @@ Eb(no3) / / / | / / / / |
     expect(lines[0].items[0]).toBeTag('title', 'Rattle');
 
     expect(lines[1].items.length).toEqual(1);
-    expect(lines[1].items[0]).toBeTag('Comment', 'Intro (5x)');
+    expect(lines[1].items[0]).toBeTag('comment', 'Intro (5x)');
 
     const line2Pairs = lines[2].items;
     expect(line2Pairs[0]).toBeChordLyricsPair('Eb(no3)', '');
@@ -212,7 +206,7 @@ Ab2 - Eb/G Eb /
     expect(lines[0].items[0]).toBeTag('title', 'Rattle');
 
     expect(lines[1].items.length).toEqual(1);
-    expect(lines[1].items[0]).toBeTag('Comment', 'Intro (5x)');
+    expect(lines[1].items[0]).toBeTag('comment', 'Intro (5x)');
 
     const line2Pairs = lines[2].items;
     expect(line2Pairs[0]).toBeChordLyricsPair('Eb(no3)', '');
@@ -315,7 +309,7 @@ Let it be
     expect(line3Pairs[1]).toBeChordLyricsPair('Am', 'be');
 
     expect(lines[4].items.length).toEqual(1);
-    expect(lines[4].items[0]).toBeTag('new_key', 'G');
+    expect(lines[4].items[0]).toBeTag('nk', 'G');
 
     const line5Pairs = lines[5].items;
     expect(line5Pairs[0]).toBeChordLyricsPair('', 'Let it ');
@@ -341,11 +335,14 @@ Let it be
     expect(lines[0].items[0]).toBeTag('title', 'Let it be');
 
     expect(lines[1].items.length).toEqual(1);
-    expect(lines[1].items[0]).toBeTag('comment', 'Chorus 1:');
+    expect(lines[1].items[0]).toBeTag('key', 'C');
 
-    const line1Pairs = lines[2].items;
-    expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
-    expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be');
+    expect(lines[2].items.length).toEqual(1);
+    expect(lines[2].items[0]).toBeTag('comment', 'Chorus 1:');
+
+    const line4Pairs = lines[3].items;
+    expect(line4Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+    expect(line4Pairs[1]).toBeChordLyricsPair('Am', 'be');
   });
 
   it('new line is not required at the end', () => {
@@ -383,9 +380,9 @@ Let it be, let it be
       expect(lines[0].items.length).toEqual(1);
       expect(lines[0].items[0]).toBeTag('comment', 'Chorus 1:');
 
-      const line2Pairs = lines[2].items;
+      const line2Pairs = lines[1].items;
       expect(line2Pairs[0]).toBeChordLyricsPair('', 'Let it ');
-      expect(line2Pairs[1]).toBeChordLyricsPair('Am', 'be,');
+      expect(line2Pairs[1]).toBeChordLyricsPair('Am', 'be, ');
       expect(line2Pairs[2]).toBeChordLyricsPair('', 'let it ');
       expect(line2Pairs[3]).toBeChordLyricsPair('C/G', 'be');
     });
@@ -405,8 +402,8 @@ Let it   be, let it be
 
       const line1Pairs = lines[1].items;
       expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it');
-      expect(line1Pairs[1]).toBeChordLyricsPair('Am', '');
-      expect(line1Pairs[2]).toBeChordLyricsPair('', ' be, let it');
+      expect(line1Pairs[1]).toBeChordLyricsPair('Am', '   ');
+      expect(line1Pairs[2]).toBeChordLyricsPair('', 'be, let it ');
       expect(line1Pairs[3]).toBeChordLyricsPair('C/G', 'be');
     });
   });

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -1,4 +1,4 @@
-import { ChordsOverWordsParser } from '../../src';
+import {ChordsOverWordsParser} from '../../src';
 
 import '../matchers';
 
@@ -144,16 +144,16 @@ Mother Mary comes to me
     const line1Pairs = lines[1].items;
     expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
     expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be');
-    expect(line1Pairs[2]).toBeChordLyricsPair('', 'Whisper words of wisdom, let it be');
 
-    expect(lines[2].items.length).toEqual(0);
+    expect(lines[2].items[0]).toBeChordLyricsPair('', 'Whisper words of wisdom, let it be');
 
-    expect(lines[3].items.length).toEqual(1);
-    expect(lines[3].items[0]).toBeTag('comment', 'Verse');
+    expect(lines[3].items.length).toEqual(0);
 
-    const lines4Pairs = lines[4].items;
-    expect(lines4Pairs[0]).toBeChordLyricsPair('', 'When I find myself in times of trouble');
-    expect(lines4Pairs[1]).toBeChordLyricsPair('', 'Mother Mary comes to me');
+    expect(lines[4].items.length).toEqual(1);
+    expect(lines[4].items[0]).toBeTag('comment', 'Verse');
+
+    expect((lines[5].items)[0]).toBeChordLyricsPair('', 'When I find myself in times of trouble');
+    expect((lines[6].items)[0]).toBeChordLyricsPair('', 'Mother Mary comes to me');
   });
 
   it('supports a chords only section with rhythm symbols ', () => {
@@ -223,7 +223,7 @@ Ab2 - Eb/G Eb /
     expect(lines[3].items.length).toEqual(0);
 
     expect(lines[4].items.length).toEqual(1);
-    expect(lines[4].items[0]).toBeTag('Comment', 'Verse 1');
+    expect(lines[4].items[0]).toBeTag('comment', 'Verse 1');
 
     const line5Pairs = lines[5].items;
     expect(line5Pairs[0]).toBeChordLyricsPair('Eb', 'Saturday ');

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -1,4 +1,4 @@
-import {ChordsOverWordsParser} from '../../src';
+import { ChordsOverWordsParser } from '../../src';
 
 import '../matchers';
 
@@ -309,7 +309,7 @@ Let it be
     expect(line3Pairs[1]).toBeChordLyricsPair('Am', 'be');
 
     expect(lines[4].items.length).toEqual(1);
-    expect(lines[4].items[0]).toBeTag('nk', 'G');
+    expect(lines[4].items[0]).toBeTag('new_key', 'G');
 
     const line5Pairs = lines[5].items;
     expect(line5Pairs[0]).toBeChordLyricsPair('', 'Let it ');

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -162,6 +162,90 @@ Mother Mary comes to me
     expect(lines4Pairs[1]).toBeChordLyricsPair('', 'Mother Mary comes to me');
   });
 
+  it('supports a chords only section with rhythm symbols ', () => {
+    const chordOverWords = `
+title: Rattle
+Intro (5x)
+Eb(no3) / / / | / / / / |
+`.substring(1);
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Rattle');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('Comment', 'Intro (5x)');
+
+    const line2Pairs = lines[2].items;
+    expect(line2Pairs[0]).toBeChordLyricsPair('Eb(no3)', '');
+    expect(line2Pairs[1]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[2]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[3]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[4]).toBeChordLyricsPair('|', '');
+    expect(line2Pairs[5]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[6]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[7]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[8]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[9]).toBeChordLyricsPair('|', '');
+  });
+
+  it('supports mixed chords only line & chords over words ', () => {
+    const chordOverWords = `
+title: Rattle
+Intro (5x)
+Eb(no3) / / / | / / / / |
+
+Verse 1
+Eb                   Ebsus         Eb      
+Saturday was silent, surely it was through
+Ab2 - Eb/G Eb /
+`.substring(1);
+
+    const parser = new ChordsOverWordsParser();
+    const song = parser.parse(chordOverWords);
+    const { lines } = song;
+
+    expect(lines[0].items.length).toEqual(1);
+    expect(lines[0].items[0]).toBeTag('title', 'Rattle');
+
+    expect(lines[1].items.length).toEqual(1);
+    expect(lines[1].items[0]).toBeTag('Comment', 'Intro (5x)');
+
+    const line2Pairs = lines[2].items;
+    expect(line2Pairs[0]).toBeChordLyricsPair('Eb(no3)', '');
+    expect(line2Pairs[1]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[2]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[3]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[4]).toBeChordLyricsPair('|', '');
+    expect(line2Pairs[5]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[6]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[7]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[8]).toBeChordLyricsPair('/', '');
+    expect(line2Pairs[9]).toBeChordLyricsPair('|', '');
+
+    expect(lines[3].items.length).toEqual(0);
+
+    expect(lines[4].items.length).toEqual(1);
+    expect(lines[4].items[0]).toBeTag('Comment', 'Verse 1');
+
+    const line5Pairs = lines[5].items;
+    expect(line5Pairs[0]).toBeChordLyricsPair('Eb', 'Saturday ');
+    expect(line5Pairs[1]).toBeChordLyricsPair('', 'was silent, ');
+    expect(line5Pairs[2]).toBeChordLyricsPair('Ebsus', 'surely ');
+    expect(line5Pairs[3]).toBeChordLyricsPair('', 'it was ');
+    expect(line5Pairs[4]).toBeChordLyricsPair('Eb', 'through');
+
+    const line6Pairs = lines[6].items;
+    expect(line6Pairs[0]).toBeChordLyricsPair('Ab2', '');
+    expect(line6Pairs[1]).toBeChordLyricsPair('-', '');
+    expect(line6Pairs[2]).toBeChordLyricsPair('Eb/G', '');
+    expect(line6Pairs[3]).toBeChordLyricsPair('Eb', '');
+    expect(line6Pairs[4]).toBeChordLyricsPair('/', '');
+  });
+
   it('parses comment without a ":"', () => {
     const chordOverWords = `
 title: Let it be


### PR DESCRIPTION
# TODO/pending:

- [ ] support numerics and numerals (only chord symbols are supported at this stage)
- [x] test with different chord sheets
- [x] the parser assumes a line of text not associated with chords is a comment, but I'm not sure that's always correct
- [x] extract the chord grammar. Add a build step to insert the chord grammar into the chord sheet grammar
- [ ] test with all kinds of chords

# Nice to have, not included in this PR:

- [ ] reuse the chord grammar for `Chord.parse`
- [ ] use the chord grammar in `ChordProParser` to have it parse chords
- [ ] we're parsing chords, but when creating a song we're cramming it into a string because that's what it expects. Instead, we should be able to incorporate the parsed chords into the song. We should either differentiate between a chord object and a chord string, or ensure a chord is always a `Chord` object (but that adds parsing overhead when you might not even need the parsed chord)
- [ ] we're parsing chords, but we're using string keys. Instead, keys (and even notes) should be objects.

Resolves #219 