### PR TITLE
different parsing approach

### DIFF
--- a/src/parser/chord_grammar.pegjs
+++ b/src/parser/chord_grammar.pegjs
@@ -9,13 +9,13 @@ ChordSymbol
     }
 
 ChordSymbolRoot
-  = [A-Ga-g]
+  = [A-Ga-g/|x-]
 
 ChordModifier
   = "#" / "b"
 
 ChordSuffix
-  = [a-zA-Z0-9]*
+  = "("? [a-zA-Z0-9]* ")"?
 
 ChordBass
   = "/" root:ChordSymbolRoot modifier:ChordModifier? {

--- a/src/parser/chord_grammar.pegjs
+++ b/src/parser/chord_grammar.pegjs
@@ -1,6 +1,6 @@
 Chord
   = chordSymbol:ChordSymbol {
-    return { type: "chord", ...chordSymbol, column: location().start.column };
+    return { type: "chord", ...chordSymbol, column: location().start.column - 1};
   }
 
 ChordSymbol
@@ -9,7 +9,7 @@ ChordSymbol
     }
 
 ChordSymbolRoot
-  = [A-Ga-g/|x-]
+  = [A-Ga-g/|x]
 
 ChordModifier
   = "#" / "b"

--- a/src/parser/chords_over_words_grammar.pegjs
+++ b/src/parser/chords_over_words_grammar.pegjs
@@ -1,21 +1,18 @@
 ChordSheet
-  = metaDataLines:MetaData? lines:ChordSheetContents? {
+  = lines:LineWithNewLine* line: Line? {
       return {
         type: "chordSheet",
-        lines: [
-          ...metaDataLines,
-          ...lines,
-        ]
+        lines: [...lines, line]
       };
     }
 
-ChordSheetContents
-  = NewLine? items:ChordSheetItem* {
+LineWithNewLine
+  = items:Line NewLine {
     return items;
   }
 
-ChordSheetItem
-  = item:(InlineMetaData / ChordLyricsLines / LyricsLine) NewLine {
+Line
+  = item:(InlineMetaData / ChordLyricsLines / LyricsLine) {
     return item;
   }
 

--- a/src/parser/chords_over_words_grammar.pegjs
+++ b/src/parser/chords_over_words_grammar.pegjs
@@ -20,8 +20,8 @@ ChordLyricsLines
   = chords:ChordsLine NewLine lyrics:Lyrics {
       const chordLyricsPairs = chords.map((chord, i) => {
          const nextChord = chords[i + 1];
-         const start = chord.column - 1;
-         const end = nextChord ? nextChord.column - 1 : lyrics.length;
+         const start = chord.column;
+         const end = nextChord ? nextChord.column : lyrics.length;
 
          return {
            type: "chordLyricsPair",
@@ -39,7 +39,7 @@ ChordLyricsLines
           chordLyricsPairs.unshift({
             type: "chordLyricsPair",
             chord: null,
-            lyrics: lyrics.substring(0, firstChordPosition - 1),
+            lyrics: lyrics.substring(0, firstChordPosition),
           });
         }
       }

--- a/test/integration/chords_over_words_to_chordpro.test.ts
+++ b/test/integration/chords_over_words_to_chordpro.test.ts
@@ -5,7 +5,6 @@ describe('chords over words to chordpro', () => {
     const chordOverWords = `
 title: Let it be
 key: C
----
 Chorus 1:
        Am         C/G        F          C
 Let it be, let it be, let it be, let it be
@@ -26,7 +25,8 @@ Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be
 [C]Whisper words of [G]wisdom, let it [F]be[C/E][Dm][C]
 
 Let it [Bbm7]be, let it [DbM7/Ab]be, let it [Gbsus2]be, let it [Db]be
-[GbM7]Whisper words of [Absus]wisdom, let it [Gb]be[Db/F][Ebm][Db]`.substring(1);
+[GbM7]Whisper words of [Absus]wisdom, let it [Gb]be[Db/F][Ebm][Db]
+`.substring(1);
 
     const song = new ChordsOverWordsParser().parse(chordOverWords);
     const actualChordPro = new ChordProFormatter().format(song);

--- a/test/parser/chords_over_words_parser.test.ts
+++ b/test/parser/chords_over_words_parser.test.ts
@@ -9,55 +9,6 @@ describe('ChordsOverWordsParser', () => {
     const chordOverWords = `
 title: Let it be
 key: C
----
-Chorus 1:
-       Am         C/G        F          C
-Let it be, let it be, let it be, let it be
-C                G              F  C/E Dm C
-Whisper words of wisdom, let it be
-`.substring(1);
-
-    const parser = new ChordsOverWordsParser();
-    const song = parser.parse(chordOverWords);
-    const { lines } = song;
-
-    expect(lines.length).toEqual(5);
-
-    expect(lines[0].items.length).toEqual(1);
-    expect(lines[0].items[0]).toBeTag('title', 'Let it be');
-
-    expect(lines[1].items.length).toEqual(1);
-    expect(lines[1].items[0]).toBeTag('key', 'C');
-
-    expect(lines[2].items.length).toEqual(1);
-    expect(lines[2].items[0]).toBeTag('comment', 'Chorus 1:');
-
-    const line3Pairs = lines[3].items;
-    expect(line3Pairs[0]).toBeChordLyricsPair('', 'Let it ');
-    expect(line3Pairs[1]).toBeChordLyricsPair('Am', 'be, ');
-    expect(line3Pairs[2]).toBeChordLyricsPair('', 'let it ');
-    expect(line3Pairs[3]).toBeChordLyricsPair('C/G', 'be, ');
-    expect(line3Pairs[4]).toBeChordLyricsPair('', 'let it ');
-    expect(line3Pairs[5]).toBeChordLyricsPair('F', 'be, ');
-    expect(line3Pairs[6]).toBeChordLyricsPair('', 'let it ');
-    expect(line3Pairs[7]).toBeChordLyricsPair('C', 'be');
-
-    const lines4Pairs = lines[4].items;
-    expect(lines4Pairs[0]).toBeChordLyricsPair('C', 'Whisper ');
-    expect(lines4Pairs[1]).toBeChordLyricsPair('', 'words of ');
-    expect(lines4Pairs[2]).toBeChordLyricsPair('F', 'wis');
-    expect(lines4Pairs[3]).toBeChordLyricsPair('G', 'dom, ');
-    expect(lines4Pairs[4]).toBeChordLyricsPair('', 'let it ');
-    expect(lines4Pairs[5]).toBeChordLyricsPair('F', 'be ');
-    expect(lines4Pairs[6]).toBeChordLyricsPair('C/E', ' ');
-    expect(lines4Pairs[7]).toBeChordLyricsPair('Dm', ' ');
-    expect(lines4Pairs[8]).toBeChordLyricsPair('C', '');
-  });
-
-  it('allows for frontmatter seperator to be optional', () => {
-    const chordOverWords = `
-title: Let it be
-key: C
 
 Chorus 1:
        Am         C/G        F          C
@@ -70,19 +21,17 @@ Whisper words of wisdom, let it be
     const song = parser.parse(chordOverWords);
     const { lines } = song;
 
-    expect(lines.length).toEqual(5);
-
     expect(lines[0].items.length).toEqual(1);
     expect(lines[0].items[0]).toBeTag('title', 'Let it be');
 
     expect(lines[1].items.length).toEqual(1);
     expect(lines[1].items[0]).toBeTag('key', 'C');
-
-    expect(lines[2].items.length).toEqual(1);
-    expect(lines[2].items[0]).toBeTag('comment', 'Chorus 1:');
 
     // this test almost works, it just doesn't maintain the space after the metadata
-    expect(lines[3].items.length).toEqual(0);
+    expect(lines[2].items.length).toEqual(0);
+
+    expect(lines[3].items.length).toEqual(1);
+    expect(lines[3].items[0]).toBeTag('comment', 'Chorus 1:');
 
     const line4Pairs = lines[4].items;
     expect(line4Pairs[0]).toBeChordLyricsPair('', 'Let it ');
@@ -97,13 +46,12 @@ Whisper words of wisdom, let it be
     const lines5Pairs = lines[5].items;
     expect(lines5Pairs[0]).toBeChordLyricsPair('C', 'Whisper ');
     expect(lines5Pairs[1]).toBeChordLyricsPair('', 'words of ');
-    expect(lines5Pairs[2]).toBeChordLyricsPair('F', 'wis');
-    expect(lines5Pairs[3]).toBeChordLyricsPair('G', 'dom, ');
-    expect(lines5Pairs[4]).toBeChordLyricsPair('', 'let it ');
-    expect(lines5Pairs[5]).toBeChordLyricsPair('F', 'be ');
-    expect(lines5Pairs[6]).toBeChordLyricsPair('C/E', ' ');
-    expect(lines5Pairs[7]).toBeChordLyricsPair('Dm', ' ');
-    expect(lines5Pairs[8]).toBeChordLyricsPair('C', '');
+    expect(lines5Pairs[2]).toBeChordLyricsPair('G', 'wisdom, ');
+    expect(lines5Pairs[3]).toBeChordLyricsPair('', 'let it ');
+    expect(lines5Pairs[4]).toBeChordLyricsPair('F', 'be');
+    expect(lines5Pairs[5]).toBeChordLyricsPair('C/E', '');
+    expect(lines5Pairs[6]).toBeChordLyricsPair('Dm', '');
+    expect(lines5Pairs[7]).toBeChordLyricsPair('C', '');
   });
 
   it('parses simple chords over words with only 1 metadata', () => {
@@ -383,11 +331,11 @@ Let it be, let it be
       expect(lines[0].items.length).toEqual(1);
       expect(lines[0].items[0]).toBeTag('comment', 'Chorus 1:');
 
-      const line2Pairs = lines[2].items;
-      expect(line2Pairs[0]).toBeChordLyricsPair('', 'Let it ');
-      expect(line2Pairs[1]).toBeChordLyricsPair('Am', 'be,');
-      expect(line2Pairs[2]).toBeChordLyricsPair('', 'let it ');
-      expect(line2Pairs[3]).toBeChordLyricsPair('C/G', 'be');
+      const line1Pairs = lines[1].items;
+      expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it ');
+      expect(line1Pairs[1]).toBeChordLyricsPair('Am', 'be, ');
+      expect(line1Pairs[2]).toBeChordLyricsPair('', 'let it ');
+      expect(line1Pairs[3]).toBeChordLyricsPair('C/G', 'be');
     });
 
     it('correctly places a trailing chord', () => {
@@ -405,8 +353,8 @@ Let it   be, let it be
 
       const line1Pairs = lines[1].items;
       expect(line1Pairs[0]).toBeChordLyricsPair('', 'Let it');
-      expect(line1Pairs[1]).toBeChordLyricsPair('Am', '');
-      expect(line1Pairs[2]).toBeChordLyricsPair('', ' be, let it');
+      expect(line1Pairs[1]).toBeChordLyricsPair('Am', ' ');
+      expect(line1Pairs[2]).toBeChordLyricsPair('', 'be, let it ');
       expect(line1Pairs[3]).toBeChordLyricsPair('C/G', 'be');
     });
   });


### PR DESCRIPTION
@martijnversluis 
So I was playing around with the way you were matching chords up with lyric pairs and wondering how it was going too work where it would only match a chord with one word like we do with chordpro parsing.

So ... I decided to try my hand at an approach. It's quite different... very different and it looks way more complicated, but it works. The tests that are still failing aren't chord placement tests.

I was able to maintain the integration test you had made, as well as pass the ones I started on Friday, as well as mirror what it should parse when there are trailing chords.

<img width="461" alt="CleanShot 2022-09-12 at 22 42 42@2x" src="https://user-images.githubusercontent.com/23046374/189818692-b8c7cd1d-5624-438c-8e09-d7bca1f7184a.png">


Definitely curious for your thoughts. There definitely could be a cleaner way to get the job done, but if you don't see any glaring red flags maybe we could merge this in, work on the rest of the tests to get the comments and lyric only lines working, and then refactor later.

<img width="510" alt="CleanShot 2022-09-12 at 22 42 16@2x" src="https://user-images.githubusercontent.com/23046374/189818631-69c8692f-95f4-4399-b191-b8d5643dc753.png">

CC: @bkeepers 