### PR TITLE
Gh 215 allow overriding metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ metadata.get('author')   // =&gt; 'John'</p>
 <a name="Metadata+get"></a>
 
 ### metadata.get(prop) ⇒ <code>Array.&lt;String&gt;</code> \| <code>String</code>
-<p>Reads a metadata value by key. This method supports simple value lookup, as fetching single array values.</p>
+<p>Reads a metadata value by key. This method supports simple value lookup, as well as fetching single array values.</p>
 <p>This method deprecates direct property access, eg: metadata['author']</p>
 <p>Examples:</p>
 <p>const metadata = new Metadata({ lyricist: 'Pete', author: ['John', 'Mary'] });

--- a/src/chord_sheet/metadata.ts
+++ b/src/chord_sheet/metadata.ts
@@ -42,11 +42,11 @@ class Metadata extends MetadataAccessors {
       });
   }
 
-  contains(key) {
+  contains(key): boolean {
     return key in this.metadata;
   }
 
-  add(key, value) {
+  add(key, value): void {
     if (isReadonlyTag(key)) {
       return;
     }
@@ -70,7 +70,7 @@ class Metadata extends MetadataAccessors {
     this.metadata[key] = [currentValue, value];
   }
 
-  set(key, value) {
+  set(key, value): void {
     if (value) {
       this.metadata[key] = value;
     } else {
@@ -105,7 +105,7 @@ class Metadata extends MetadataAccessors {
    * @returns {Array<String>|String} the metadata value(s). If there is only one value, it will return a String,
    * else it returns an array of strings.
    */
-  get(prop) {
+  get(prop): string | string[] | undefined {
     if (prop === _KEY) {
       return this.calculateKeyFromCapo();
     }
@@ -124,7 +124,7 @@ class Metadata extends MetadataAccessors {
    * @param {string} prop the property name
    * @returns {String} The metadata value
    */
-  getSingle(prop) {
+  getSingle(prop): string {
     const value = this.get(prop);
 
     if (Array.isArray(value)) {
@@ -134,11 +134,11 @@ class Metadata extends MetadataAccessors {
     return value;
   }
 
-  parseArrayKey(prop) {
+  parseArrayKey(prop): [string, number] | null {
     const match = prop.match(/(.+)\.(-?\d+)$/);
 
     if (!match) {
-      return [];
+      return null;
     }
 
     const key = match[1];
@@ -146,13 +146,14 @@ class Metadata extends MetadataAccessors {
     return [key, index];
   }
 
-  getArrayItem(prop) {
-    const [key, index] = this.parseArrayKey(prop);
+  getArrayItem(prop): string | undefined {
+    const parsedKey = this.parseArrayKey(prop);
 
-    if (!(key && index)) {
+    if (parsedKey === null) {
       return undefined;
     }
 
+    const [key, index] = parsedKey;
     const arrayValue = (this.metadata[key] || []);
     let itemIndex = index;
 
@@ -169,11 +170,11 @@ class Metadata extends MetadataAccessors {
    * Returns a deep clone of this Metadata object
    * @returns {Metadata} the cloned Metadata object
    */
-  clone() {
+  clone(): Metadata {
     return new Metadata(this.metadata);
   }
 
-  calculateKeyFromCapo() {
+  calculateKeyFromCapo(): string | undefined {
     const capo = this.getSingle(CAPO);
     const key = this.getSingle(KEY);
 

--- a/src/chord_sheet/metadata.ts
+++ b/src/chord_sheet/metadata.ts
@@ -28,18 +28,15 @@ class Metadata extends MetadataAccessors {
   constructor(metadata = null) {
     super();
 
-    Object
-      .keys(metadata || {})
-      .filter((key) => !isReadonlyTag(key))
-      .forEach((key) => {
-        const value = metadata[key];
+    if (metadata) {
+      this.assign(metadata);
+    }
+  }
 
-        if (value instanceof Array) {
-          this.metadata[key] = [...value];
-        } else {
-          this.metadata[key] = value;
-        }
-      });
+  merge(metadata: Record<string, string | string[]>): Metadata {
+    const clone = this.clone();
+    clone.assign(metadata);
+    return clone;
   }
 
   contains(key): boolean {
@@ -83,7 +80,7 @@ class Metadata extends MetadataAccessors {
   }
 
   /**
-   * Reads a metadata value by key. This method supports simple value lookup, as fetching single array values.
+   * Reads a metadata value by key. This method supports simple value lookup, as well as fetching single array values.
    *
    * This method deprecates direct property access, eg: metadata['author']
    *
@@ -183,6 +180,21 @@ class Metadata extends MetadataAccessors {
     }
 
     return undefined;
+  }
+
+  private assign(metadata: Record<string, string | string[]>) {
+    Object
+      .keys(metadata)
+      .filter((key) => !isReadonlyTag(key))
+      .forEach((key) => {
+        const value = metadata[key];
+
+        if (value instanceof Array) {
+          this.metadata[key] = [...value];
+        } else {
+          this.metadata[key] = value;
+        }
+      });
   }
 }
 

--- a/test/chord_sheet/metadata.test.ts
+++ b/test/chord_sheet/metadata.test.ts
@@ -99,4 +99,31 @@ describe('Metadata', () => {
       });
     });
   });
+
+  describe('merge', () => {
+    it('returns a new Metadata object where metadata is merged with the supplied metadata', () => {
+      const original = new Metadata({ artist: 'Bill', composer: 'John' });
+      const merged = original.merge({ artist: 'Mary' });
+
+      expect(merged.artist).toEqual('Mary');
+      expect(merged.composer).toEqual('John');
+    });
+
+    it('does not deep-merge array values', () => {
+      const original = new Metadata({ artist: ['Bill'], composer: 'John' });
+      const merged = original.merge({ artist: ['Mary'] });
+
+      expect(merged.artist).toEqual(['Mary']);
+      expect(merged.composer).toEqual('John');
+    });
+
+    it('does not override read-only keys', () => {
+      const original = new Metadata({ key: 'Ab', capo: 3 });
+      const merged = original.merge({ _key: 'G#' });
+
+      expect(merged.key).toEqual('Ab');
+      expect(merged.capo).toEqual(3);
+      expect(merged.get('_key')).toEqual('B');
+    });
+  });
 });


### PR DESCRIPTION
Add `Metadata.merge()` function

It returns a new Metadata object where metadata is merged with the supplied metadata.

Resolves #215